### PR TITLE
swapping pager's adapter bugfix

### DIFF
--- a/carbon/src/main/java/carbon/widget/PagerTabStrip.java
+++ b/carbon/src/main/java/carbon/widget/PagerTabStrip.java
@@ -149,16 +149,15 @@ public class PagerTabStrip extends HorizontalScrollView {
         if (adapter == null)
             return;
 
-        if (tabBuilder == null) {
-            tabBuilder = new TabBuilder() {
-                @Override
-                public View getView(int position) {
-                    View tab = inflate(getContext(), R.layout.carbon_tab, null);
-                    ((TextView) tab.findViewById(R.id.carbon_tabText)).setText(adapter.getPageTitle(position).toString().toUpperCase());
-                    return tab;
-                }
-            };
-        }
+        tabBuilder = new TabBuilder() {
+            @Override
+            public View getView(int position) {
+                View tab = inflate(getContext(), R.layout.carbon_tab, null);
+                ((TextView) tab.findViewById(R.id.carbon_tabText)).setText(adapter.getPageTitle(position).toString().toUpperCase());
+                return tab;
+            }
+        };
+
         for (int i = 0; i < adapter.getCount(); i++) {
             View tab = tabBuilder.getView(i);
             content.addView(tab, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));


### PR DESCRIPTION
In Carbon the using of ViewPager and PagerTabStrip is following:

``` java
pager.setAdapter(new MyPagerAdapter(myData));
pagerTabStrip.setViewPager(pager);
```

When the pager's dataset is changed, one needs to call `pagerTabStrip.setViewPager(pager);` again in order to update the tabStrip. However, there is a bug: the `TabBuilder` instance of `pagerTabStrip` is not updated and keeps a reference to the old adapter (see `initTabs()`), that makes the data inconsistent or throws exceptions. In my case, the number of tabs and their titles can be changed. 

There are several ways to fix this, I suppose there is nothing bad in making new instance of TabBuilder, as I propose in this request.

Ideally, the PagerTabStrip should be updated automatically. 

Like this project!:thumbsup:
